### PR TITLE
Add to raise an error when executed multiple times

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import confirm from "./confirm.js";
 import method from "./method.js";
+import loadState from "./utils/loadState.js";
 
 const start = function () {
   startConfirm();
@@ -7,11 +8,23 @@ const start = function () {
 };
 
 const startConfirm = function () {
+  const moduleName = "confirm";
+  loadState.checkLoaded(moduleName);
+
+  // start
   confirm.start();
+
+  loadState.setLoaded(moduleName);
 };
 
 const startMethod = function () {
+  const moduleName = "method";
+  loadState.checkLoaded(moduleName);
+
+  // start
   method.start();
+
+  loadState.setLoaded(moduleName);
 };
 
 export default { start, startConfirm, startMethod };

--- a/src/utils/loadState.js
+++ b/src/utils/loadState.js
@@ -1,0 +1,41 @@
+// State store
+// window.__ALT_UJS__: { loaded_confirm: true|falseloaded_method: true|false }
+//
+const setLoaded = function (module) {
+  if (window.__ALT_UJS__ === undefined) {
+    window.__ALT_UJS__ = {};
+  }
+
+  window.__ALT_UJS__[key(module)] = true;
+};
+
+const isLoaded = function (module) {
+  if (window.__ALT_UJS__ === undefined) {
+    return false;
+  }
+
+  if (window.__ALT_UJS__[key(module)] === true) {
+    return true;
+  }
+
+  return false;
+};
+
+// Raise an error to prevent multiple event listeners from being registered when alt-ujs is executed more than once.
+const checkLoaded = function (module) {
+  if (isLoaded(module)) {
+    throw new Error(`alt-ujs: ${module} module has already been loaded.`);
+  }
+
+  return true;
+};
+
+const key = function (module) {
+  if (!module) {
+    return;
+  }
+
+  return "loaded_" + module;
+};
+
+export default { setLoaded, checkLoaded };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,14 +1,48 @@
-import { expect, test } from "vitest";
+import { expect, test, describe, afterEach } from "vitest";
 import AltUjs from "../src/index.js";
 
-test("export start", async () => {
-  expect(AltUjs.start).not.toBeNull();
+afterEach(async () => {
+  window.__ALT_UJS__ = undefined;
 });
 
-test("export startConfirm", async () => {
-  expect(AltUjs.startConfirm).not.toBeNull();
+describe("#start", () => {
+  test("export start", () => {
+    expect(AltUjs.start).not.toBeNull();
+  });
+
+  test("raise an error when start twice", () => {
+    AltUjs.start();
+
+    expect(() => AltUjs.start()).toThrowError(
+      "alt-ujs: confirm module has already been loaded.",
+    );
+  });
 });
 
-test("export startMethod", async () => {
-  expect(AltUjs.startMethod).not.toBeNull();
+describe("#startConfirm", () => {
+  test("export startConfirm", () => {
+    expect(AltUjs.startConfirm).not.toBeNull();
+  });
+
+  test("raise an error when start twice", () => {
+    AltUjs.startConfirm();
+
+    expect(() => AltUjs.startConfirm()).toThrowError(
+      "alt-ujs: confirm module has already been loaded.",
+    );
+  });
+});
+
+describe("#startMethod", () => {
+  test("export startMethod", () => {
+    expect(AltUjs.startMethod).not.toBeNull();
+  });
+
+  test("raise an error when start twice", () => {
+    AltUjs.startMethod();
+
+    expect(() => AltUjs.startMethod()).toThrowError(
+      "alt-ujs: method module has already been loaded.",
+    );
+  });
 });

--- a/test/utils/loadState.test.js
+++ b/test/utils/loadState.test.js
@@ -1,0 +1,48 @@
+import { expect, test, describe, afterEach } from "vitest";
+import loadState from "../../src/utils/loadState.js";
+
+const moduleName = "test_module";
+
+afterEach(async () => {
+  window.__ALT_UJS__ = undefined;
+});
+
+describe("#setLoaded", () => {
+  test("set the loaded state for a single module", () => {
+    loadState.setLoaded(moduleName);
+
+    expect(window.__ALT_UJS__.loaded_test_module).toBe(true);
+  });
+
+  test("set the loaded state for a multiple module", () => {
+    loadState.setLoaded(moduleName);
+    loadState.setLoaded("test2");
+
+    expect(window.__ALT_UJS__.loaded_test_module).toBe(true);
+    expect(window.__ALT_UJS__.loaded_test2).toBe(true);
+  });
+
+  test("return undefined when no loaded state is set", () => {
+    expect(window.__ALT_UJS__).toBeUndefined();
+  });
+});
+
+describe("#checkLoaded", () => {
+  test("raise an error when the module has already been loaded", () => {
+    loadState.setLoaded(moduleName);
+
+    expect(() => loadState.checkLoaded(moduleName)).toThrowError(
+      "alt-ujs: test_module module has already been loaded.",
+    );
+  });
+
+  test("return true for a different module's loaded state", () => {
+    loadState.setLoaded("test2");
+
+    expect(loadState.checkLoaded(moduleName)).toBe(true);
+  });
+
+  test("return true when no loaded state is set for the module", () => {
+    expect(loadState.checkLoaded(moduleName)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Summary
Raise an error to prevent multiple event listeners from being registered when alt-ujs is executed more than once.

### Details
If `start()` is executed twice as shown below:
```js
import AltUjs from "alt-ujs";

AltUjs.start();

...

AltUjs.start();
```

The following error occurs:
> Uncaught Error: alt-ujs: confirm has already been loaded.

(`confirm` is the module name of alt-ujs that was called twice.)
