### PR TITLE
Add a check to prevent simultaneous use of rails-ujs and alt-ujs

### DIFF
--- a/src/utils/loadState.js
+++ b/src/utils/loadState.js
@@ -23,6 +23,8 @@ const isLoaded = function (module) {
 
 // Raise an error to prevent multiple event listeners from being registered when alt-ujs is executed more than once.
 const checkLoaded = function (module) {
+  checkLoadedRails();
+
   if (isLoaded(module)) {
     throw new Error(`alt-ujs: ${module} module has already been loaded.`);
   }
@@ -36,6 +38,18 @@ const key = function (module) {
   }
 
   return "loaded_" + module;
+};
+
+// check to load rails-ujs
+const checkLoadedRails = function () {
+  if (window._rails_loaded) {
+    // https://github.com/rails/rails/blob/7-1-stable/actionview/app/javascript/rails-ujs/index.js#L135
+    throw new Error(
+      `If you load both rails-ujs and alt-ujs, use alt-ujs only.`,
+    );
+  }
+
+  return true;
 };
 
 export default { setLoaded, checkLoaded };

--- a/test/utils/loadState.test.js
+++ b/test/utils/loadState.test.js
@@ -45,4 +45,15 @@ describe("#checkLoaded", () => {
   test("return true when no loaded state is set for the module", () => {
     expect(loadState.checkLoaded(moduleName)).toBe(true);
   });
+
+  // for rails-ujs
+  test("raise an error when the rails-ujs is loaded", () => {
+    window._rails_loaded = true;
+
+    expect(() => loadState.checkLoaded(moduleName)).toThrowError(
+      "If you load both rails-ujs and alt-ujs, use alt-ujs only.",
+    );
+
+    window._rails_loaded = undefined;
+  });
 });


### PR DESCRIPTION
### Summary
Raises an error if both `rails-ujs` and `alt-ujs` are loaded, ensuring only `alt-ujs` is used when both are present.

### Details
If both `alt-ujs` and `rails-ujs` are loaded, events like the `confirm` event may be triggered multiple times.
To prevent this, an error is raised when `rails-ujs` is detected.

Whether `rails-ujs` is loaded is determined by checking `window._rails_loaded`.
https://github.com/rails/rails/blob/7-1-stable/actionview/app/javascript/rails-ujs/index.js#L135
