### PR TITLE
Add `files` field to ignore unnecessary files in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "alternative rails-ujs",
   "type": "module",
   "main": "src/index.js",
+  "files": [
+    "src"
+  ],
   "scripts": {
     "lint": "eslint src test",
     "format": "eslint src test --fix",


### PR DESCRIPTION
### Summary
Ignore unnecessary files in the package

### Details
Since the `files` field is not specified in the `package.json`, the default value of `["*"]` was used, which included unnecessary files.
This pull request modifies the configuration to specify only the required `src` folder in the `files` field.

For more details:
https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files
