### PR TITLE
Add resetDisable method to exports

### DIFF
--- a/src/disable.js
+++ b/src/disable.js
@@ -45,4 +45,4 @@ const resetDisableEvent = function () {
   });
 };
 
-export default { start };
+export default { start, resetDisableEvent };

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,10 @@ const startDisable = function () {
   loadState.setLoaded(moduleName);
 };
 
+const resetDisable = function () {
+  disable.resetDisableEvent();
+};
+
 const startMethod = function () {
   const moduleName = "method";
   loadState.checkLoaded(moduleName);
@@ -39,4 +43,4 @@ const startMethod = function () {
   loadState.setLoaded(moduleName);
 };
 
-export default { start, startConfirm, startDisable, startMethod };
+export default { start, startConfirm, startDisable, resetDisable, startMethod };

--- a/test/disable.test.js
+++ b/test/disable.test.js
@@ -1,6 +1,6 @@
 import { expect, test, beforeEach, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { setDisableFormEvents } from "../src/disable.js";
+import disable, { setDisableFormEvents } from "../src/disable.js";
 
 let calledSubmit = false;
 
@@ -57,4 +57,18 @@ test("disable the form submit button when entering input element", async () => {
 
   const elementSubmit = document.getElementById("id-submit");
   expect(elementSubmit.disabled).toBe(true);
+});
+
+test("reset disable event", async () => {
+  // prepare
+  const element = document.getElementById("id-submit");
+  const user = userEvent.setup();
+  await user.click(element);
+  const elementSubmit = document.getElementById("id-submit");
+  expect(elementSubmit.disabled).toBe(true);
+
+  disable.resetDisableEvent();
+
+  // assert
+  expect(elementSubmit.disabled).toBe(false);
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,6 +47,12 @@ describe("#startDisable", () => {
   });
 });
 
+describe("#resetDisable", () => {
+  test("export resetDisable", () => {
+    expect(AltUjs.resetDisable()).not.toBeNull();
+  });
+});
+
 describe("#startMethod", () => {
   test("export startMethod", () => {
     expect(AltUjs.startMethod).not.toBeNull();


### PR DESCRIPTION
### Summary
Add `resetDisable` to the default export to make it available for external use.
The `resetDisable` function allows external modules to reset the disabled state managed by the disable module.