### PR TITLE
Fix an issue caused by an npm bug by adding optionalDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "jsdom": "^26.0.0",
         "prettier": "^3.3.3",
         "vitest": "^3.0.4"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.34.8"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "prettier": "^3.3.3",
     "vitest": "^3.0.4"
   },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "^4.34.8"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
### Summary
Fix an issue caused by an npm bug by adding platform-specific `optionalDependencies`.

### Details
Add `@rollup/rollup-linux-x64-gnu` as an `optionalDependencies` for CI.
This fixes an npm bug where platform-specific optional dependencies could not be resolved.
https://github.com/npm/cli/issues/4828

```
Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
```
Error details can be found in the GitHub Actions log:
https://github.com/taketo1113/alt-ujs/actions/runs/13510687479/job/37750156884?pr=47
