### PR TITLE
Remove @rollup/rollup-linux-x64-gnu from optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,8 @@
     "globals": "^16.0.0",
     "jsdom": "^26.0.0",
     "prettier": "^3.3.3",
+    "rollup": "^4.34.8",
     "vitest": "^3.0.4"
-  },
-  "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.34.8"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Summary
Remove `@rollup/rollup-linux-x64-gnu` from `optionalDependencies` to add `devDependencies` of `rollup`.

### Details
The `optionalDependencies` are only required during the development of alt-ujs, but they are also added to the dependencies during alt-ujs installation.
Therefore, they will be replaced with `devDependencies` of `rollup`.

### Related Links
- #56