### PR TITLE
Add refreshCSRFTokens to refresh CSRF tokens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,15 @@
 import confirm from "./confirm.js";
 import disable from "./disable.js";
 import method from "./method.js";
+import csrf from "./utils/csrf.js";
 import loadState from "./utils/loadState.js";
 
 const start = function () {
   startConfirm();
   startDisable();
   startMethod();
+
+  document.addEventListener("DOMContentLoaded", csrf.refreshCSRFTokens);
 };
 
 const startConfirm = function () {

--- a/src/utils/csrf.js
+++ b/src/utils/csrf.js
@@ -14,4 +14,17 @@ const csrfParam = function () {
   }
 };
 
-export default { csrfToken, csrfParam };
+const refreshCSRFTokens = function () {
+  const token = csrfToken();
+  const param = csrfParam();
+
+  if (token && param) {
+    return document
+      .querySelectorAll('form input[name="' + param + '"]')
+      .forEach(function (input) {
+        input.value = token;
+      });
+  }
+};
+
+export default { csrfToken, csrfParam, refreshCSRFTokens };

--- a/test/utils/csrf.test.js
+++ b/test/utils/csrf.test.js
@@ -12,6 +12,12 @@ beforeEach(async () => {
   csrfparam = document.createElement("meta");
   csrfparam.setAttribute("name", "csrf-param");
   csrfparam.setAttribute("content", "authenticity_token");
+
+  const form = document.createElement("form");
+  const formContent =
+    '<input id="id-token" type="hidden" name="authenticity_token" value="">';
+  form.innerHTML = formContent;
+  document.body.appendChild(form);
 });
 
 afterEach(async () => {
@@ -22,6 +28,11 @@ afterEach(async () => {
   const param = document.querySelector("meta[name=csrf-param]");
   if (param) {
     document.head.removeChild(csrfparam);
+  }
+
+  const form = document.querySelector("form");
+  if (form) {
+    document.body.removeChild(form);
   }
 });
 
@@ -50,5 +61,24 @@ describe("#csrfParam", () => {
   test("not get csrf param without mata of csrf-param", () => {
     const csrfParam = csrf.csrfParam();
     expect(csrfParam).toBeUndefined();
+  });
+});
+
+describe("#refreshCSRFTokens", () => {
+  test("set csrf token", () => {
+    document.head.appendChild(csrftoken);
+    document.head.appendChild(csrfparam);
+
+    csrf.refreshCSRFTokens();
+
+    const element = document.getElementById("id-token");
+    expect(element.value).toBe("xxxxxxxx");
+  });
+
+  test("not set csrf token without token & param", () => {
+    csrf.refreshCSRFTokens();
+
+    const element = document.getElementById("id-token");
+    expect(element.value).toBe("");
   });
 });


### PR DESCRIPTION
### Summary
This Pull Request adds `refreshCSRFTokens` to refresh CSRF tokens in forms on `DOMContentLoaded`.

### Details
To prevent issues caused by outdated CSRF tokens, the token is refreshed and the form fields are updated on `DOMContentLoaded`.
