### PR TITLE
Add Node.js 24.x to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Node.js ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Update the CI matrix for Node.js 24.x.

## Changes
- add Node.js 24.x to CI

## Related URL
- What’s New with Node.js 24 | OpenJS Foundation
  - https://openjsf.org/blog/nodejs-24-released
